### PR TITLE
Use stream to delay fetching files

### DIFF
--- a/src/main/scala/com/eneco/trading/kafka/connect/ftp/source/FtpFileLister.scala
+++ b/src/main/scala/com/eneco/trading/kafka/connect/ftp/source/FtpFileLister.scala
@@ -8,8 +8,11 @@ import org.apache.commons.net.ftp.{FTPClient, FTPFile}
 
 // org.apache.commons.net.ftp.FTPFile only contains the relative path
 case class AbsoluteFtpFile(ftpFile:FTPFile, parentDir:String) {
-  def path() = Paths.get(parentDir, ftpFile.getName).toString
-  def age(): Duration = Duration.between(ftpFile.getTimestamp.toInstant, Instant.now)
+  def name() = ftpFile.getName
+  def size() = ftpFile.getSize
+  def timestamp() = ftpFile.getTimestamp.toInstant
+  def path() = Paths.get(parentDir, name).toString
+  def age(): Duration = Duration.between(timestamp, Instant.now)
 }
 
 case class FtpFileLister(ftp: FTPClient) extends StrictLogging {

--- a/src/main/scala/com/eneco/trading/kafka/connect/ftp/source/FtpMonitor.scala
+++ b/src/main/scala/com/eneco/trading/kafka/connect/ftp/source/FtpMonitor.scala
@@ -15,8 +15,6 @@ import scala.util.{Failure, Success, Try}
 // a full downloaded file
 case class FetchedFile(meta:FileMetaData, body: Array[Byte])
 
-
-
 // tells to monitor which directory and how files are dealt with, might be better a trait and is TODO
 case class MonitoredPath(path:String, tail:Boolean) {
   val p = Paths.get(if (path.endsWith("/")) path + "*" else path)
@@ -24,117 +22,103 @@ case class MonitoredPath(path:String, tail:Boolean) {
 
 // a potential partial file
 case class FileBody(bytes:Array[Byte], offset:Long)
+object EmptyFileBody extends FileBody(Array[Byte](), 0)
 
 // instructs the FtpMonitor how to do its things
-case class FtpMonitorSettings(host:String, port:Option[Int], user:String, pass:String, maxAge: Option[Duration],directories: Seq[MonitoredPath], timeoutMs:Int)
-
-
+case class FtpMonitorSettings(host:String, port:Option[Int], user:String, pass:String, maxAge: Option[Duration], directories: Seq[MonitoredPath], timeoutMs:Int)
 
 class FtpMonitor(settings:FtpMonitorSettings, fileConverter: FileConverter) extends StrictLogging {
   val MaxAge = settings.maxAge.getOrElse(Duration.ofDays(Long.MaxValue))
 
   val ftp = new FTPClient()
 
-  def requiresFetch(file: AbsoluteFtpFile): Boolean = {
-    // Reduce calls to metastore by checking age first
-    !MaxAge.minus(file.age).isNegative && (fileConverter.getFileOffset(file.path) match {
-      case None => true
-      case Some(known) if known.attribs.size != file.ftpFile.getSize => true
-      case Some(known) if known.attribs.timestamp != file.ftpFile.getTimestamp.toInstant => true
-      case _ => false
-    })
+  def requiresFetch(file: AbsoluteFtpFile, metadata: Option[FileMetaData]): Boolean = metadata match {
+    case None => logger.debug(s"${file.name} hasn't been seen before"); true
+    case Some(known) if known.attribs.size != file.ftpFile.getSize => {
+      logger.debug(s"${file.name} size changed ${known.attribs.size} => ${file.size}")
+      true
+    }
+    case Some(known) if known.attribs.timestamp != file.timestamp => {
+      logger.debug(s"${file.name} is newer ${known.attribs.timestamp} => ${file.timestamp}")
+      true
+    }
+    case _ => false
   }
 
   // Retrieves the FtpAbsoluteFile and returns a new or updated KnownFile
-  def fetch(file: AbsoluteFtpFile, knownFile: Option[FileMetaData]): Try[FetchedFile] = {
-    logger.info(s"fetch ${file.path}")
+  def fetch(file: AbsoluteFtpFile, prevFetch: Option[FileMetaData]): Option[(Option[FileMetaData], FetchedFile)] = {
+    logger.info(s"fetching ${file.path}")
     val baos = new ByteArrayOutputStream()
+
     if (ftp.retrieveFile(file.path, baos)) {
       val bytes = baos.toByteArray
       baos.close()
       val hash = DigestUtils.sha256Hex(bytes)
-      Success(FetchedFile(knownFile match {
-        case None => FileMetaData(new FileAttributes(file.path, file.ftpFile.getSize, file.ftpFile.getTimestamp.toInstant), hash, Instant.now, Instant.now, Instant.now)
-        case Some(old) => FileMetaData(new FileAttributes(file.path, file.ftpFile.getSize, file.ftpFile.getTimestamp.toInstant), hash, old.firstFetched, old.lastModified, Instant.now)
-      }, bytes))
+      val attributes = new FileAttributes(file.path, file.ftpFile.getSize, file.ftpFile.getTimestamp.toInstant)
+      val meta = prevFetch match {
+        case None => FileMetaData(attributes, hash, Instant.now, Instant.now, Instant.now)
+        case Some(old) => FileMetaData(attributes, hash, old.firstFetched, old.lastModified, Instant.now)
+      }
+      Option(prevFetch, FetchedFile(meta, bytes))
     } else {
-      new Failure(new Exception("ftp says no: " + ftp.getReplyString))
+      logger.warn(s"failed to fetch ${file.path}: ${ftp.getReplyString}")
+      None
     }
   }
 
   // translates a MonitoredDirectory and previously known FileMetaData into a FileMetaData and FileBody
-  def handleFetchedFile(w:MonitoredPath, optPreviously: Option[FileMetaData], current:FetchedFile): (FileMetaData, Option[FileBody]) =
-    optPreviously match {
+  def handleFetchedFile(tail: Boolean, prevFetch: Option[FileMetaData], current: FetchedFile): (FileMetaData, FileBody) =
+    prevFetch match {
       case Some(previously) if previously.attribs.size != current.meta.attribs.size || previously.hash != current.meta.hash =>
         // file changed in size and/or hash
         logger.info(s"fetched ${current.meta.attribs.path}, it was known before and it changed")
-        if (w.tail) {
+        if (tail) {
           if (current.meta.attribs.size > previously.attribs.size) {
             val hashPrevBlock = DigestUtils.sha256Hex(util.Arrays.copyOfRange(current.body, 0, previously.attribs.size.toInt))
             if (previously.hash == hashPrevBlock) {
               logger.info(s"tail ${current.meta.attribs.path} [${previously.attribs.size.toInt}, ${current.meta.attribs.size.toInt})")
               val tail = util.Arrays.copyOfRange(current.body, previously.attribs.size.toInt, current.meta.attribs.size.toInt)
-              (current.meta.inspectedNow().modifiedNow(), Some(FileBody(tail,previously.attribs.size)))
+              (current.meta.inspectedNow().modifiedNow(), FileBody(tail, previously.attribs.size))
             } else {
               logger.warn(s"the tail of ${current.meta.attribs.path} is to be followed, but previously seen content changed. we'll provide the entire file.")
-              (current.meta.inspectedNow().modifiedNow(), Some(FileBody(current.body,0)))
+              (current.meta.inspectedNow().modifiedNow(), FileBody(current.body, 0))
             }
           } else {
             // the file shrunk or didn't grow
             logger.warn(s"the tail of ${current.meta.attribs.path} is to be followed, but it shrunk")
-            (current.meta.inspectedNow().modifiedNow(), None)
+            (current.meta.inspectedNow().modifiedNow(), EmptyFileBody)
           }
-        } else { // !w.tail: we're not tailing but dumping the entire file on change
+        } else {
+          // !tail: we're not tailing but dumping the entire file on change
           logger.info(s"dump entire ${current.meta.attribs.path}")
-          (current.meta.inspectedNow().modifiedNow(), Some(FileBody(current.body,0)))
+          (current.meta.inspectedNow().modifiedNow(), FileBody(current.body, 0))
         }
       case Some(_) =>
         // file didn't change
         logger.info(s"fetched ${current.meta.attribs.path}, it was known before and it didn't change")
-        (current.meta.inspectedNow(), None)
+        (current.meta.inspectedNow(), EmptyFileBody)
       case None =>
         // file is new
         logger.info(s"fetched ${current.meta.attribs.path}, wasn't known before")
         logger.info(s"dump entire ${current.meta.attribs.path}")
-        (current.meta.inspectedNow().modifiedNow(), Some(FileBody(current.body,0)))
+        (current.meta.inspectedNow().modifiedNow(), FileBody(current.body, 0))
     }
-
-  def debugLogFiles(files:Seq[AbsoluteFtpFile], w:MonitoredPath): Unit = files.foreach(f =>
-      {
-        logger.debug(s"${f.ftpFile}")
-        logger.debug(s"${f.ftpFile.getName} age is ${f.age}; MaxAge is ${MaxAge}")
-      }
-    )
 
 
   // fetches files from a monitored directory when needed
-  def fetchFromMonitoredPlaces(w:MonitoredPath): Seq[(FileMetaData, Option[FileBody])] = {
-    val files = FtpFileLister(ftp).listFiles(w.p.toString)
-    val toBeFetched = files.filter(requiresFetch(_))
+  def fetchFromMonitoredPlaces(w:MonitoredPath): Stream[(FileMetaData, FileBody)] = {
+    val files = FtpFileLister(ftp).listFiles(w.p.toString).filter(f => !MaxAge.minus(f.age).isNegative)
+    logger.info(s"Found ${files.length} items in ${w.p}")
 
-    debugLogFiles(files, w)
-
-    logger.info(s"we'll be fetching ${toBeFetched.length} items from ${w.p}")
-    toBeFetched.foreach(f=>
-      {
-        val kf = fileConverter.getFileOffset(f.path)
-        logger.info(s"we'll be fetching ${f.path} ${f.ftpFile.getSize} ${f.ftpFile.getTimestamp.toInstant} (age: ${f.age})")
-        logger.info(s"what we knew from our store of ${f.path}: " + (kf match {
-          case Some(f) => s"${f.attribs.size} ${f.attribs.timestamp}"
-          case None => "not known before"
-        }))
-      })
-
-    val previouslyKnown = toBeFetched.map(f => fileConverter.getFileOffset(f.path))
-
-    val fetchResults = toBeFetched zip previouslyKnown map { case (f, k) => fetch(f, k) }
-
-    toBeFetched zip previouslyKnown zip fetchResults map { case((a,b),c) => (a,b,c)} flatMap {
-      case (ftpFile, optPrevKnown, Success(currentFile)) => Some(handleFetchedFile(w, optPrevKnown, currentFile))
-      case (ftpFile, _, Failure(err)) =>
-        logger.warn(s"failed to fetch ${ftpFile.path}: ${err.toString}")
-        None
-    }
+    files.toStream
+      // Get the metadata from the offset store
+      .map(file => (file , fileConverter.getFileOffset(file.path)))
+      // Filter out the files that do not need to be fetched
+      .filter{ case (file, offset) => requiresFetch(file, offset) }
+      // Fetch the latest file contents
+      .flatMap{ case (file, offset) => fetch(file, offset) }
+      // Extract the file changes depending on the tracking mode
+      .map{ case (prevFile, currentFile) => handleFetchedFile(w.tail, prevFile, currentFile) }
   }
 
   def connectFtp(): Try[FTPClient] = {
@@ -177,21 +161,11 @@ class FtpMonitor(settings:FtpMonitorSettings, fileConverter: FileConverter) exte
     Success(ftp)
   }
 
-  def poll(): Try[Seq[(FileMetaData, FileBody, MonitoredPath)]] = Try(connectFtp() match {
+  def poll(): Try[Stream[(FileMetaData, FileBody, MonitoredPath)]] = connectFtp() match {
       case Success(_) =>
-        val v = settings.directories.flatMap(w => {
-          val results: Seq[(FileMetaData, Option[FileBody])] = fetchFromMonitoredPlaces(w)
-          results.flatMap {
-            case (meta, Some(body)) =>
-              logger.info(s"${meta.attribs.path} got @ offset ${body.offset}")
-              Some((meta,body, w))
-            case (meta, None) =>
-              logger.info(s"${meta.attribs.path} got no bytes")
-              None
-          }
-        })
-        Success(v)
+        Try(settings.directories.toStream.flatMap(dir =>
+          fetchFromMonitoredPlaces(dir).map { case (meta, body) => (meta, body, dir) }))
       case Failure(err) => logger.warn(s"cannot connect to ftp: ${err.toString}")
         Failure(err)
-    }).flatten
+    }
 }

--- a/src/main/scala/com/eneco/trading/kafka/connect/ftp/source/FtpSourceConfig.scala
+++ b/src/main/scala/com/eneco/trading/kafka/connect/ftp/source/FtpSourceConfig.scala
@@ -30,6 +30,7 @@ object FtpSourceConfig {
   val StructKeyStyle = "struct"
   val FileConverter = "ftp.fileconverter"
   val SourceRecordConverter = "ftp.sourcerecordconverter"
+  val FtpMaxPollRecords = "ftp.max.poll.records"
 
   val definition: ConfigDef = new ConfigDef()
     .define(Address, Type.STRING, Importance.HIGH, "ftp address[:port]")
@@ -43,6 +44,7 @@ object FtpSourceConfig {
     .define(KeyStyle, Type.STRING, Importance.HIGH, s"what the output key is set to: `${StringKeyStyle}` => filename; `${StructKeyStyle}` => structure with filename and offset")
     .define(FileConverter, Type.CLASS, "com.eneco.trading.kafka.connect.ftp.source.SimpleFileConverter", Importance.HIGH, s"TODO")
     .define(SourceRecordConverter, Type.CLASS, "com.eneco.trading.kafka.connect.ftp.source.NopSourceRecordConverter", Importance.HIGH, s"TODO")
+    .define(FtpMaxPollRecords, Type.INT, 10000, Importance.LOW, "Max number of records returned per poll")
 }
 
 // abstracts the properties away a bit
@@ -70,4 +72,6 @@ class FtpSourceConfig(props: util.Map[String, String])
   def fileConverter = getClass(FtpSourceConfig.FileConverter)
 
   def timeoutMs() = 30*1000
+
+  def maxPollRecords = getInt(FtpSourceConfig.FtpMaxPollRecords)
 }

--- a/src/main/scala/com/eneco/trading/kafka/connect/ftp/source/SimpleFileConverter.scala
+++ b/src/main/scala/com/eneco/trading/kafka/connect/ftp/source/SimpleFileConverter.scala
@@ -3,6 +3,7 @@ package com.eneco.trading.kafka.connect.ftp.source
 import java.util
 
 import com.eneco.trading.kafka.connect.ftp.source.SourceRecordProducers.SourceRecordProducer
+import com.typesafe.scalalogging.slf4j.StrictLogging
 import org.apache.kafka.connect.data.{Schema, SchemaBuilder, Struct}
 import org.apache.kafka.connect.source.SourceRecord
 import org.apache.kafka.connect.storage.OffsetStorageReader
@@ -14,7 +15,7 @@ import scala.collection.JavaConverters._
   * including the file attributes.
   */
 class SimpleFileConverter(props: util.Map[String, String], offsetStorageReader : OffsetStorageReader)
-  extends FileConverter(props, offsetStorageReader) {
+  extends FileConverter(props, offsetStorageReader) with StrictLogging {
 
   val cfg = new FtpSourceConfig(props)
   val metaStore = new ConnectFileMetaDataStore(offsetStorageReader)
@@ -25,6 +26,7 @@ class SimpleFileConverter(props: util.Map[String, String], offsetStorageReader :
   }
 
   override def convert(topic: String, meta: FileMetaData, body: FileBody): Seq[SourceRecord] = {
+    logger.info(s"File contents ${new String(body.bytes, "UTF-8")}")
     metaStore.set(meta.attribs.path, meta)
     recordConverter.convert(recordMaker(metaStore, topic, meta, body)).asScala
   }

--- a/src/main/scala/com/eneco/trading/kafka/connect/ftp/source/SimpleFileConverter.scala
+++ b/src/main/scala/com/eneco/trading/kafka/connect/ftp/source/SimpleFileConverter.scala
@@ -3,7 +3,6 @@ package com.eneco.trading.kafka.connect.ftp.source
 import java.util
 
 import com.eneco.trading.kafka.connect.ftp.source.SourceRecordProducers.SourceRecordProducer
-import com.typesafe.scalalogging.slf4j.StrictLogging
 import org.apache.kafka.connect.data.{Schema, SchemaBuilder, Struct}
 import org.apache.kafka.connect.source.SourceRecord
 import org.apache.kafka.connect.storage.OffsetStorageReader
@@ -15,7 +14,7 @@ import scala.collection.JavaConverters._
   * including the file attributes.
   */
 class SimpleFileConverter(props: util.Map[String, String], offsetStorageReader : OffsetStorageReader)
-  extends FileConverter(props, offsetStorageReader) with StrictLogging {
+  extends FileConverter(props, offsetStorageReader) {
 
   val cfg = new FtpSourceConfig(props)
   val metaStore = new ConnectFileMetaDataStore(offsetStorageReader)
@@ -26,7 +25,6 @@ class SimpleFileConverter(props: util.Map[String, String], offsetStorageReader :
   }
 
   override def convert(topic: String, meta: FileMetaData, body: FileBody): Seq[SourceRecord] = {
-    logger.info(s"File contents ${new String(body.bytes, "UTF-8")}")
     metaStore.set(meta.attribs.path, meta)
     recordConverter.convert(recordMaker(metaStore, topic, meta, body)).asScala
   }


### PR DESCRIPTION
This modification uses a stream to reduce the memory usage of the connector. It will only return `FtpMaxPollRecords` at a time, and will only fetch enough files to deliver that.